### PR TITLE
Adding short-circuit to write if user includes file structure on init

### DIFF
--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#97CA00" d="M63 0h36v20H63z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">96%</text>
+        <text x="80" y="14">96%</text>
     </g>
 </svg>

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -32,10 +32,13 @@ def create_directory(file_path):
 
 
 class Project:
-    def __init__(self):
-        self._base_dir = None
-        self._tmp = None
-        self._files = {}
+    def __init__(self, base_dir=None, files=None):
+        self._base_dir = base_dir
+        self._files = files or {}
+
+        # If the user passed in a file structure on init, then short-circuit to the `write`
+        if self._files != None:
+            self.write(self._files)
 
     def __del__(self):
         # Ensure we clean up the temp dir structure on delete
@@ -45,7 +48,11 @@ class Project:
         return self
 
     def __exit__(self, *args):
-        shutil.rmtree(self.base_dir)
+        try:
+            shutil.rmtree(self.base_dir)
+        except FileNotFoundError:
+            # No need to do anything, file structure has already been cleaned up!
+            pass
 
     @property
     def base_dir(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -40,8 +40,7 @@ def test_improper_write(test_input):
 def test_proper_write_with_cleanup():
     base_dir = None
 
-    with Project() as p:
-        p.write(GOOD_NESTED_DIRS)
+    with Project(files=GOOD_NESTED_DIRS) as p:
         base_dir = p.base_dir
 
         assert path.exists(base_dir) and path.isdir(base_dir)


### PR DESCRIPTION
## Description
Adding the ability for users to pass in `files` param on `Project` instance initialization. If the `files` param is used, then the project directory structure will be created on context entry without having to explicitly call the `write()` function after the `Project` instance is created.

Also fixed the `FileNotFound` error being raised on `Project` instance deletion

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
