### PR TITLE
Adding 'ignore_patterns' parameter to read function

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -77,6 +77,14 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "bracex"
+version = "2.3.post1"
+description = "Bash style brace expander."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "certifi"
 version = "2022.9.14"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -619,8 +627,8 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
 name = "syrupy"
-version = "3.0.0"
-description = "PyTest Snapshot Test Utility"
+version = "3.0.2"
+description = "Pytest Snapshot Test Utility"
 category = "dev"
 optional = false
 python-versions = ">=3.7,<4"
@@ -701,6 +709,17 @@ docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "
 testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "wcmatch"
+version = "8.4.1"
+description = "Wildcard/glob file name matcher."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+bracex = ">=2.1.1"
+
+[[package]]
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -723,7 +742,7 @@ docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "362be0870a9acd9ebc5d1a8af771e719cf5409249a97ad7a4850b6e14b957d78"
+content-hash = "fefb5a42d2f49a231ab961b179ba13f3dcf3059bf87e3e36fb45a5b547ba27aa"
 
 [metadata.files]
 astroid = []
@@ -731,6 +750,7 @@ atomicwrites = []
 attrs = []
 bandit = []
 black = []
+bracex = []
 certifi = []
 cfgv = []
 charset-normalizer = []
@@ -786,5 +806,6 @@ typed-ast = []
 typing-extensions = []
 urllib3 = []
 virtualenv = []
+wcmatch = []
 wrapt = []
 zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [  #! Update me
 python = "^3.7"
 importlib_metadata = {version = "^4.5.0", python = "<3.8"}
 dict-path = "^1.0.1"
+wcmatch = "^8.4.1"
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.1"
 black = {version = "^22.8.0", allow-prereleases = true}

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -4,9 +4,10 @@ import glob
 import os
 import shutil
 import tempfile
-from pathlib import Path
+from re import compile, fullmatch
 
 from dict_path import extract_dict, inject_dict
+from wcmatch.pathlib import DOTGLOB, GLOBSTAR, NEGATE, NEGATEALL, NODOTDIR, Path
 
 from python_fixturify_project.exceptions import InvalidProjectError
 from python_fixturify_project.path_utils import create_directory, write_to_file
@@ -81,11 +82,13 @@ class Project:
             self.merge_files(dir_json)
         self.__write_project()
 
-    def read(self):
-        """Reads the contents of the base_dir to a dict"""
+    def read(self, ignore_patterns=["**/.git", "**/.git/*"]):
+        """Reads the contents of the base_dir to a dict and ignores any files/dirs matched by the glob expressions"""
         files: Dict[str, Any] = {}
 
-        for path in Path(self.base_dir).rglob("*"):
+        for path in Path(self.base_dir).rglob(
+            "*", exclude=ignore_patterns, flags=DOTGLOB | GLOBSTAR
+        ):
             rel_path = path.relative_to(self.base_dir)
 
             if str(rel_path) == ".":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+bracex==2.3.post1; python_version >= "3.7"
 dict-path==1.0.1; python_version >= "3.6"
 importlib-metadata==4.12.0; python_version < "3.8"
 typing-extensions==4.3.0; python_version >= "3.7" and python_version < "3.8"
+wcmatch==8.4.1; python_version >= "3.7"
 zipp==3.8.1; python_version >= "3.7" and python_version < "3.8"

--- a/tests/__snapshots__/test_project.ambr
+++ b/tests/__snapshots__/test_project.ambr
@@ -18,6 +18,16 @@
     'valid_file.txt': 'some text',
   })
 # ---
+# name: test_read_ignore_files
+  dict({
+    '.github': dict({
+      'do_not_ignore_me': dict({
+        'a_file': 'some text',
+      }),
+    }),
+    'do_not_ignore_me': 'some text',
+  })
+# ---
 # name: test_read_recreates_project_from_disc
   dict({
     '.a_hidden_folder': dict({

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,3 +75,18 @@ def test_read_recreates_project_from_disc_with_similar_filenames(snapshot):
         dir_json = p.read()
 
         assert dir_json == snapshot
+
+
+def test_read_ignore_files(snapshot):
+    files = {
+        ".git": {"a_nested_dir": {}},
+        ".github": {"ignore_me": {}, "do_not_ignore_me": {"a_file": "some text"}},
+        "ignore_me": "some text",
+        "do_not_ignore_me": "some text",
+    }
+
+    with Project(files=files) as p:
+
+        dir_json = p.read(ignore_patterns=["**/.git", "**/.git/*", "**/ignore_me"])
+
+        assert dir_json == snapshot


### PR DESCRIPTION
## Description
Adding the ability for users to exclude certain files/dirs to be returned when using the `read()` function by including a `ignore_patterns` parameter, which defaults to excluding all `.git` directories and their contents.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
