### PR TITLE
Fixing bug in read ignore_patterns default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ files = {
 
 with Project(files=files) as p:
 
-    dir_json = p.read(ignore_patterns=["**/.git", "**/.git/*", "**/ignore_me"])  # Default is ["**/.git", "**/.git/*"]
+    dir_json = p.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])  # Default is ["**/.git", "**/.git/**"]
 
 assert dir_json == {
     '.github': {

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,7 +86,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "certifi"
-version = "2022.9.14"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -548,7 +548,7 @@ pytest = ">=3.0.0,<8.0.0"
 
 [[package]]
 name = "pyupgrade"
-version = "2.38.0"
+version = "2.38.2"
 description = "A tool to automatically upgrade syntax for newer versions."
 category = "dev"
 optional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "python-fixturify-project"
-version = "0.1.3"
+version = "0.1.5"
 description = "Dynamic fixture creation for your tests"
 readme = "README.md"
 authors = ["python-fixturify-project <steve.calvert@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "python-fixturify-project"
-version = "0.1.5"
+version = "0.1.3"
 description = "Dynamic fixture creation for your tests"
 readme = "README.md"
 authors = ["python-fixturify-project <steve.calvert@gmail.com>"]

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -81,7 +81,7 @@ class Project:
             self.merge_files(dir_json)
         self.__write_project()
 
-    def read(self, ignore_patterns=["**/.git", "**/.git/*"]):
+    def read(self, ignore_patterns=["**/.git", "**/.git/**"]):
         """Reads the contents of the base_dir to a dict and ignores any files/dirs matched by the glob expressions"""
         files: Dict[str, Any] = {}
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -79,7 +79,7 @@ def test_read_recreates_project_from_disc_with_similar_filenames(snapshot):
 
 def test_read_ignore_files(snapshot):
     files = {
-        ".git": {"a_nested_dir": {}},
+        ".git": {"a_nested_dir": {"last_nested_dir": {"a_file": "some text"}}},
         ".github": {"ignore_me": {}, "do_not_ignore_me": {"a_file": "some text"}},
         "ignore_me": "some text",
         "do_not_ignore_me": "some text",
@@ -87,6 +87,6 @@ def test_read_ignore_files(snapshot):
 
     with Project(files=files) as p:
 
-        dir_json = p.read(ignore_patterns=["**/.git", "**/.git/*", "**/ignore_me"])
+        dir_json = p.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])
 
         assert dir_json == snapshot


### PR DESCRIPTION
## Description
Correcting a bug in the `ignore_patterns` default value for the `read()` function. Previously, the default value was `["**/.git", "**/.git/*"]` which would only exclude the files/dirs one level deep in the `.git` directory, and still include any files or sub-directories that were more than one level down in that directory.

This PR corrects that issue, so now the default value will exclude the `.git` directory as well as all files and sub-directories (at all levels) within the `.git` directory.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/scalvert/python-fixturify-project/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
