### PR TITLE
feat: Forces files dict to be populated before reading on both project.files and project.get

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -171,6 +171,20 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [[package]]
+name = "deepdiff"
+version = "5.8.1"
+description = "Deep Difference and Search of any Python object/data."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+ordered-set = ">=4.1.0,<4.2.0"
+
+[package.extras]
+cli = ["clevercsv (==0.7.1)", "click (==8.0.3)", "pyyaml (==5.4.1)", "toml (==0.10.2)"]
+
+[[package]]
 name = "dict-path"
 version = "1.0.1"
 description = "Python library to work with complicated nested dict"
@@ -342,6 +356,17 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*
 
 [package.dependencies]
 setuptools = "*"
+
+[[package]]
+name = "ordered-set"
+version = "4.1.0"
+description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+dev = ["black", "mypy", "pytest"]
 
 [[package]]
 name = "packaging"
@@ -711,7 +736,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "27889e0002d4e63e14a42d48219af857f0e1206958cb637edebd17a04b87c0c4"
+content-hash = "6164c2968f7adc58c5bdfc61a174140c06dcee8e2c807692a53caab48706b52b"
 
 [metadata.files]
 astroid = [
@@ -841,6 +866,10 @@ darglint = [
     {file = "darglint-1.8.1-py3-none-any.whl", hash = "sha256:5ae11c259c17b0701618a20c3da343a3eb98b3bc4b5a83d31cdd94f5ebdced8d"},
     {file = "darglint-1.8.1.tar.gz", hash = "sha256:080d5106df149b199822e7ee7deb9c012b49891538f14a11be681044f0bb20da"},
 ]
+deepdiff = [
+    {file = "deepdiff-5.8.1-py3-none-any.whl", hash = "sha256:e9aea49733f34fab9a0897038d8f26f9d94a97db1790f1b814cced89e9e0d2b7"},
+    {file = "deepdiff-5.8.1.tar.gz", hash = "sha256:8d4eb2c4e6cbc80b811266419cb71dd95a157094a3947ccf937a94d44943c7b8"},
+]
 dict-path = [
     {file = "dict-path-1.0.1.tar.gz", hash = "sha256:84e000a359e9b20d1dfffacdcdc99b35bc4f6ef6390a75195c2444c1701c5f1f"},
     {file = "dict_path-1.0.1-py3-none-any.whl", hash = "sha256:c56fe94bfbb01f40101c114cd8d8b885d5e61973d03ace7737a93058753e863c"},
@@ -960,6 +989,10 @@ mypy-extensions = [
 nodeenv = [
     {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
     {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
+ordered-set = [
+    {file = "ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8"},
+    {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ python = "^3.8"
 importlib_metadata = {version = "^4.5.0", python = "<3.8"}
 dict-path = "^1.0.1"
 wcmatch = "^8.4.1"
+deepdiff = "^5.8.1"
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.1"
 black = {version = "^22.8.0", allow-prereleases = true}

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -52,6 +52,9 @@ class Project:
     @property
     def files(self):
         """Gets the files containing the project's directory structure."""
+        if not self._files:
+            self._files = self.read()
+
         return self._files
 
     @files.setter
@@ -97,9 +100,14 @@ class Project:
             else:
                 self.__add_dir(files, rel_path)
 
+        self._files = files
+
         return files
 
     def get(self, object_path: str):
+        if self._files == {}:
+            self._files = self.read()
+
         return extract_dict(self._files, object_path)
 
     def __add_file(self, files, path, contents):

--- a/tests/__snapshots__/test_project.ambr
+++ b/tests/__snapshots__/test_project.ambr
@@ -1,3 +1,25 @@
+# name: test_get_files_after_copy
+  dict({
+    'dir': dict({
+      'dir2': dict({
+        'three.py': '# and this makes 3!!!',
+      }),
+      'two.py': '# another python',
+    }),
+    'one.py': '# some python',
+  })
+# ---
+# name: test_get_from_copied_files
+  dict({
+    'dir': dict({
+      'dir2': dict({
+        'three.py': '# and this makes 3!!!',
+      }),
+      'two.py': '# another python',
+    }),
+    'one.py': '# some python',
+  })
+# ---
 # name: test_get_from_files[dir2]
   dict({
     'three.py': '# and this makes 3!!!',

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,11 +1,11 @@
 """Tests for Project class."""
+from distutils.dir_util import copy_tree
 from os import path
 from pathlib import Path
-from deepdiff import DeepDiff
-from distutils.dir_util import copy_tree
 
 import pytest
 from conftest import BAD_DIR_NAME, BAD_EMPTY_NAME, GOOD_NESTED_DIRS, GOOD_SINGLE_FILE
+from deepdiff import DeepDiff
 
 from python_fixturify_project.exceptions import InvalidProjectError
 from python_fixturify_project.project import Project
@@ -90,7 +90,6 @@ def test_get_from_copied_files(snapshot):
 
     assert project2.files == snapshot
     assert DeepDiff(project1.files, project2.files) == {}
-
 
 
 @pytest.mark.parametrize("test_input", [BAD_DIR_NAME, BAD_EMPTY_NAME])


### PR DESCRIPTION
## Description
Currently when accessing the `project.files` dict or using the `project.get` method, if the contents of the project's `base_dir` is created via other means, such as a copy_tree call, the changes aren't immediately reflected in the `project.files` property. This change ensures the `project.files` prop is force-reloaded before access.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
