### PR TITLE
Converting context manager to dispose method

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ from python_fixturify_project import Project
 
 
 def test_mutating_project(snapshot):
-    with Project(files=INITIAL_DIR_JSON) as p:
-      mutate_files_for_some_reason(p.base_dir)
+    project = Project(files=INITIAL_DIR_JSON)
 
-      # ensure mutations were as expected
-      assert project.read() == snapshot
+    mutate_files_for_some_reason(p.base_dir)
+
+    # ensure mutations were as expected
+    assert project.read() == snapshot
 ```
 
 Or you can use the `project.get` method to get the path to a file in the project.
@@ -114,11 +115,12 @@ Or you can use the `project.get` method to get the path to a file in the project
 from python_fixturify_project import Project
 
 def test_mutating_project(snapshot):
-    with Project(files=INITIAL_DIR_JSON) as p:
-      mutate_files_for_some_reason(p.base_dir)
+    project = Project(files=INITIAL_DIR_JSON)
 
-      # ensure mutations were as  for single file
-      assert project.get('path/to/a/file.py') == snapshot(name='path/to/a/file.py')
+    mutate_files_for_some_reason(p.base_dir)
+
+    # ensure mutations were as  for single file
+    assert project.get('path/to/a/file.py') == snapshot(name='path/to/a/file.py')
 ```
 
 ## 🛡 License

--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ dir_json = {
 }
 
 # create a new project with the given directory structure
-with Project(files=dir_json) as p:
-  # add new files to the project, merging with the existing directory structure
-  p.write({
-      "new_file.txt": "some text"
-  })
+project = Project(files=dir_json)
+# add new files to the project, merging with the existing directory structure
+p.write({
+    "new_file.txt": "some text"
+})
 
-  # read the actual contents on disc
-  actual_dir_json = p.read()
+# read the actual contents on disc
+actual_dir_json = p.read()
 ```
 
 ### Ignore Files
 
-By default, the `read()` function will ignore all `.git` directories in your Project file structure. This can be overridden by using the `ignore_patterns` function parameter, which
+By default, the `read()` function will ignore all hidden files and directories in your Project file structure. This can be overridden by using the `ignore_patterns` function parameter, which
 takes a list of glob pattern strings. This may be slightly confusing, as glob patterns are normally used in an ***inclusive*** manner when performing file-system searches, however any patterns
 provided to the `ignore_patterns` parameter will be used in an ***exclusive*** manner. For example:
 
@@ -78,9 +78,9 @@ files = {
     "do_not_ignore_me": "some text",
 }
 
-with Project(files=files) as p:
+project = Project(files=files)
 
-    dir_json = p.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])  # Default is ["**/.git", "**/.git/**"]
+dir_json = project.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])  # Default is ["**/.git", "**/.git/**"]
 
 assert dir_json == {
     '.github': {

--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
-        <text x="80" y="14">95%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">92%</text>
+        <text x="80" y="14">92%</text>
     </g>
 </svg>

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -75,11 +75,6 @@ class Project:
             # No need to do anything, file structure has already been cleaned up!
             pass
 
-    def __auto_base_dir(self):
-        """Creates and sets the base_dir if not explicitly configured during init"""
-        if not self._base_dir:
-            self._base_dir = tempfile.mkdtemp()
-
     def merge_files(self, dir_json):
         """Merges an object containing a directory represention with the existing files."""
         self.files = deep_merge(self.files, dir_json)
@@ -118,6 +113,11 @@ class Project:
             self._files = self.read()
 
         return extract_dict(self._files, object_path)
+
+    def __auto_base_dir(self):
+        """Creates and sets the base_dir if not explicitly configured during init"""
+        if not self._base_dir:
+            self._base_dir = tempfile.mkdtemp()
 
     def __add_file(self, files, path, contents):
         file = os.path.basename(path)

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -22,17 +22,7 @@ class Project:
 
     def __del__(self):
         # Ensure we clean up the temp dir structure on delete
-        self.__exit__()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        try:
-            shutil.rmtree(self.base_dir)
-        except FileNotFoundError:
-            # No need to do anything, file structure has already been cleaned up!
-            pass
+        self.dispose()
 
     @property
     def base_dir(self):
@@ -66,6 +56,13 @@ class Project:
     def files(self):
         """Deletes the files corresponding to the project's directory structure."""
         del self._files
+
+    def dispose(self):
+        try:
+            shutil.rmtree(self.base_dir)
+        except FileNotFoundError:
+            # No need to do anything, file structure has already been cleaned up!
+            pass
 
     def __auto_base_dir(self):
         """Creates and sets the base_dir if not explicitly configured during init"""

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -12,11 +12,14 @@ from python_fixturify_project.exceptions import InvalidProjectError
 from python_fixturify_project.path_utils import create_directory, write_to_file
 from python_fixturify_project.utils import deep_merge, keys_exists
 
+DEFAULT_IGNORE_PATTERNS = ["**/.git", "**/.git/**"]
+
 
 class Project:
-    def __init__(self, base_dir=None, files=None):
+    def __init__(self, base_dir=None, files=None, ignore_patterns=[]):
         self._base_dir = base_dir
         self._files = files or {}
+        self._ignore_patterns = DEFAULT_IGNORE_PATTERNS + ignore_patterns
 
         self.write(self._files)
 
@@ -79,12 +82,12 @@ class Project:
             self.merge_files(dir_json)
         self.__write_project()
 
-    def read(self, ignore_patterns=["**/.git", "**/.git/**"]):
+    def read(self):
         """Reads the contents of the base_dir to a dict and ignores any files/dirs matched by the glob expressions"""
         files: Dict[str, Any] = {}
 
         for path in Path(self.base_dir).rglob(
-            "*", exclude=ignore_patterns, flags=DOTGLOB | GLOBSTAR
+            "*", exclude=self._ignore_patterns, flags=DOTGLOB | GLOBSTAR
         ):
             rel_path = path.relative_to(self.base_dir)
 

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -139,29 +139,30 @@ class Project:
         self.__auto_base_dir()
         self.__write(self.files, self.base_dir)
 
-    def __write(self, dir_structure, full_path):
+    def __write(self, files, full_path):
         """Recursive write helper function. Does the bulk of the work in terms of writing the directory structure"""
-        # Base case
-        if not dir_structure or not isinstance(dir_structure, dict):
+        if not files or not isinstance(files, dict):
             return
 
-        # Save the original path
         original_dir = Path(full_path)
-        for entry in dir_structure:
+
+        for entry in files:
             full_path = Path(full_path, entry)
+
             if not isinstance(entry, str) or entry == "":
                 raise InvalidProjectError(
                     "Invalid directory structure given. Each key must be a non-empty string"
                 )
-            if isinstance(dir_structure[entry], str):  # This is a file
-                write_to_file(full_path, dir_structure[entry])
+
+            if isinstance(files[entry], str):
+                write_to_file(full_path, files[entry])
             else:
                 if entry == "." or entry == "..":
                     raise InvalidProjectError('Directory entry must not be "." or ".."')
 
                 create_directory(full_path)
                 # Our recursion step, which should only happen if we find ourselves a nested directory
-                self.__write(dir_structure=dir_structure[entry], full_path=full_path)
+                self.__write(files=files[entry], full_path=full_path)
 
             # Reset the original path because Python will still remember the value of `full_path` even after we return from recursion
             full_path = original_dir

--- a/tests/__snapshots__/test_project.ambr
+++ b/tests/__snapshots__/test_project.ambr
@@ -36,7 +36,7 @@
 # name: test_get_from_files[one.py]
   '# some python'
 # ---
-# name: test_proper_write_with_cleanup
+# name: test_proper_write_with_dispose
   dict({
     '.a_hidden_folder': dict({
       'nested_dir': dict({

--- a/tests/__snapshots__/test_project.ambr
+++ b/tests/__snapshots__/test_project.ambr
@@ -36,6 +36,47 @@
 # name: test_get_from_files[one.py]
   '# some python'
 # ---
+# name: test_multiple_writes_correctly_merges[merged_files]
+  dict({
+    '.a_hidden_folder': dict({
+      'nested_dir': dict({
+        '.a_hidden_file': 'some text',
+      }),
+    }),
+    'another.py': 'Yet another!!!',
+    'nested_dir': dict({
+      'another_nested_dir': dict({
+        'final_text_file.txt': 'some text',
+        'last_nested_empty_dir': dict({
+        }),
+      }),
+      'another_nested_empty_dir': dict({
+      }),
+      'valid_empty_file.txt': '',
+    }),
+    'valid_file.txt': 'some text',
+  })
+# ---
+# name: test_multiple_writes_correctly_merges[original_files]
+  dict({
+    '.a_hidden_folder': dict({
+      'nested_dir': dict({
+        '.a_hidden_file': 'some text',
+      }),
+    }),
+    'nested_dir': dict({
+      'another_nested_dir': dict({
+        'final_text_file.txt': 'some text',
+        'last_nested_empty_dir': dict({
+        }),
+      }),
+      'another_nested_empty_dir': dict({
+      }),
+      'valid_empty_file.txt': '',
+    }),
+    'valid_file.txt': 'some text',
+  })
+# ---
 # name: test_proper_write_with_dispose
   dict({
     '.a_hidden_folder': dict({
@@ -43,6 +84,7 @@
         '.a_hidden_file': 'some text',
       }),
     }),
+    'another.py': 'Yet another!!!',
     'nested_dir': dict({
       'another_nested_dir': dict({
         'final_text_file.txt': 'some text',
@@ -73,6 +115,7 @@
         '.a_hidden_file': 'some text',
       }),
     }),
+    'another.py': 'Yet another!!!',
     'nested_dir': dict({
       'another_nested_dir': dict({
         'final_text_file.txt': 'some text',

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -95,6 +95,18 @@ def test_improper_write(test_input):
         project.write(test_input)
 
 
+def test_multiple_writes_correctly_merges(snapshot):
+    project = Project(files=GOOD_NESTED_DIRS)
+
+    assert project.files == snapshot(name="original_files")
+
+    project.write({
+        'another.py': 'Yet another!!!'
+    })
+
+    assert project.files == snapshot(name="merged_files")
+
+
 def test_proper_write_with_dispose(snapshot):
     base_dir = None
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -145,8 +145,8 @@ def test_read_ignore_files(snapshot):
         "do_not_ignore_me": "some text",
     }
 
-    project = Project(files=files)
+    project = Project(files=files, ignore_patterns=["**/ignore_me"])
 
-    dir_json = project.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])
+    dir_json = project.read()
 
     assert dir_json == snapshot

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,3 @@
-"""Tests for Project class."""
 from distutils.dir_util import copy_tree
 from os import path
 from pathlib import Path
@@ -23,17 +22,14 @@ def test_project_has_base_dir_on_instantiation():
 
 
 def test_cleanup_dir():
-    # Given
     project = Project()
     project.write(GOOD_SINGLE_FILE)
     base_dir = project.base_dir
 
     assert path.exists(base_dir) and path.isdir(base_dir)
 
-    # When
     del project
 
-    # Then
     assert not path.exists(base_dir)
 
 
@@ -99,26 +95,28 @@ def test_improper_write(test_input):
         project.write(test_input)
 
 
-def test_proper_write_with_cleanup(snapshot):
+def test_proper_write_with_dispose(snapshot):
     base_dir = None
 
-    with Project(files=GOOD_NESTED_DIRS) as p:
-        base_dir = p.base_dir
+    project = Project(files=GOOD_NESTED_DIRS)
 
-        assert path.exists(base_dir) and path.isdir(base_dir)
+    base_dir = project.base_dir
 
-        assert p.read() == snapshot
+    assert path.exists(base_dir) and path.isdir(base_dir)
 
-    # Ensure cleanup happened
+    assert project.read() == snapshot
+
+    project.dispose()
+
     assert not path.exists(base_dir)
 
 
 def test_read_recreates_project_from_disc(snapshot):
-    with Project(files=GOOD_NESTED_DIRS) as p:
+    project = Project(files=GOOD_NESTED_DIRS)
 
-        dir_json = p.read()
+    dir_json = project.read()
 
-        assert dir_json == snapshot
+    assert dir_json == snapshot
 
 
 def test_read_recreates_project_from_disc_with_similar_filenames(snapshot):
@@ -132,11 +130,11 @@ def test_read_recreates_project_from_disc_with_similar_filenames(snapshot):
         },
     }
 
-    with Project(files=files) as p:
+    project = Project(files=files)
 
-        dir_json = p.read()
+    dir_json = project.read()
 
-        assert dir_json == snapshot
+    assert dir_json == snapshot
 
 
 def test_read_ignore_files(snapshot):
@@ -147,8 +145,8 @@ def test_read_ignore_files(snapshot):
         "do_not_ignore_me": "some text",
     }
 
-    with Project(files=files) as p:
+    project = Project(files=files)
 
-        dir_json = p.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])
+    dir_json = project.read(ignore_patterns=["**/.git", "**/.git/**", "**/ignore_me"])
 
-        assert dir_json == snapshot
+    assert dir_json == snapshot

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -100,9 +100,7 @@ def test_multiple_writes_correctly_merges(snapshot):
 
     assert project.files == snapshot(name="original_files")
 
-    project.write({
-        'another.py': 'Yet another!!!'
-    })
+    project.write({"another.py": "Yet another!!!"})
 
     assert project.files == snapshot(name="merged_files")
 


### PR DESCRIPTION
## Description

This PR makes a few fundamental changes to the `Project` class:

- Removes the context manager implementation in favor of an explicit `dispose` method. This addresses potential confusion for consumers who were using the context manager but neglected to nest any assertions that rely on the underlying project's structure on disc, which would cause errors due to the tmp dir being deleted upon `__exit__`.
- Removes the `base_dir` keyword arg from the constructor - there's never an expectation that consumers create their own `base_dir`, but if they do it can be set via the `base_dir` setter as a fallback.
- Fixes and makes consistent the internal use of `_base_dir` to avoid infinite recursion situations.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
