### PR TITLE
feat: Adding FIXTURIFY_SKIP_DISPOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ def test_mutating_project(snapshot):
     assert project.get('path/to/a_file.py') == snapshot(name='path/to/a_file.py')
 ```
 
+## Skip Dispose (for debugging)
+
+If you want to skip the `dispose()` call, you can set the `FIXTURIFY_SKIP_DISPOSE` environment variable to `1`.
+
+```bash
+FIXTURIFY_SKIP_DISPOSE=1 pytest
+```
+
+This can be useful if you want to inspect the contents of the temporary directory after the test has completed.
+
 ## 🛡 License
 
 [![License](https://img.shields.io/github/license/scalvert/python-fixturify-project)](https://github.com/scalvert/python-fixturify-project/blob/master/LICENSE)

--- a/python_fixturify_project/project.py
+++ b/python_fixturify_project/project.py
@@ -75,6 +75,11 @@ class Project:
 
     def dispose(self) -> None:
         try:
+            skip_dispose = os.environ.get("FIXTURIFY_SKIP_DISPOSE", False)
+
+            if skip_dispose:
+                return
+
             shutil.rmtree(self._base_dir)
         except FileNotFoundError:
             # No need to do anything, file structure has already been cleaned up!


### PR DESCRIPTION
## Description

Adds a `FIXTURIFY_SKIP_DISPOSE` env var that allows you to skip the tmp directory cleanup. This can be useful if you want to inspect the contents of the tmp directory after the test has completed, or for debugging purposes.

